### PR TITLE
parameter for turning off nextJS compression

### DIFF
--- a/reflex/.templates/web/next.config.js
+++ b/reflex/.templates/web/next.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   reactStrictMode: true,
+  compress: true,
 };

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -203,6 +203,9 @@ class Config(Base):
     # Timeout when launching the gunicorn server.
     timeout: int = constants.TIMEOUT
 
+    # Whether to enable or disable nextJS gzip compression.
+    next_compression: bool = True
+
     def __init__(self, *args, **kwargs):
         """Initialize the config values.
 

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -81,6 +81,8 @@ WEB_ASSETS_DIR = os.path.join(WEB_DIR, "public")
 TAILWIND_CONFIG = os.path.join(WEB_DIR, "tailwind.config.js")
 # Default Tailwind content paths
 TAILWIND_CONTENT = ["./pages/**/*.{js,ts,jsx,tsx}"]
+# The NextJS config file
+NEXT_CONFIG_FILE = "next.config.js"
 # The sitemap config file.
 SITEMAP_CONFIG_FILE = os.path.join(WEB_DIR, "next-sitemap.config.js")
 # The node modules directory.

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -223,7 +223,6 @@ def initialize_web_directory():
                 lines[i] = new_line
 
     with open(next_config_file, "w") as file:
-        console.log(lines)
         file.writelines(lines)
 
     # Write the current version of distributed reflex package to a REFLEX_JSON."""

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -207,10 +207,24 @@ def initialize_app_directory(app_name: str, template: constants.Template):
 def initialize_web_directory():
     """Initialize the web directory on reflex init."""
     console.log("Initializing the web directory.")
-    path_ops.rm(os.path.join(constants.WEB_TEMPLATE_DIR, constants.NODE_MODULES))
-    path_ops.rm(os.path.join(constants.WEB_TEMPLATE_DIR, constants.PACKAGE_LOCK))
     path_ops.cp(constants.WEB_TEMPLATE_DIR, constants.WEB_DIR)
     path_ops.mkdir(constants.WEB_ASSETS_DIR)
+
+    # update nextJS config based on rxConfig
+    next_config_file = os.path.join(constants.WEB_DIR, constants.NEXT_CONFIG_FILE)
+
+    with open(next_config_file, "r") as file:
+        lines = file.readlines()
+        for i, line in enumerate(lines):
+            if "compress:" in line:
+                new_line = line.replace(
+                    "true", "true" if get_config().next_compression else "false"
+                )
+                lines[i] = new_line
+
+    with open(next_config_file, "w") as file:
+        console.log(lines)
+        file.writelines(lines)
 
     # Write the current version of distributed reflex package to a REFLEX_JSON."""
     with open(constants.REFLEX_JSON, "w") as f:


### PR DESCRIPTION
### Description

add a `bool` parameter called next_compression allowing to turn off the NextJS Gzip compression

The compression is still turned on by default for better performance.

### Checklist

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

