### PR TITLE
reflex: respect "env" from rxconfig

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -66,7 +66,7 @@ def init(
 @cli.command()
 def run(
     env: constants.Env = typer.Option(
-        constants.Env.DEV, help="The environment to run the app in."
+        get_config().env, help="The environment to run the app in."
     ),
     frontend: bool = typer.Option(
         False, "--frontend-only", help="Execute only frontend."


### PR DESCRIPTION
set the default for `reflex run` `--env` parameter based on the value in rxconfig.py

Fixes #1254